### PR TITLE
Added noticeboard frontend and backend and terraform files

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,1 @@
+from app.main import app

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,9 @@
+import os
+from motor.motor_asyncio import AsyncIOMotorClient
+
+MONGO_URL = os.getenv("MONGO_URL", "mongodb://localhost:27017")
+DB_NAME = os.getenv("DB_NAME", "noticeboard")
+
+client = AsyncIOMotorClient(MONGO_URL)
+db = client[DB_NAME]
+notices_collection = db["notices"]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,20 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from app.routes.notices import router as notices_router
+
+app = FastAPI(title="Noticeboard API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(notices_router)
+
+
+@app.get("/health", tags=["health"])
+async def health():
+    return {"status": "ok"}

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel, Field
+from typing import Optional
+from datetime import datetime
+
+
+class NoticeCreate(BaseModel):
+    title: str
+    content: str
+    author: Optional[str] = "Admin"
+
+
+class NoticeResponse(BaseModel):
+    id: str
+    title: str
+    content: str
+    author: str
+    created_at: datetime

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,0 +1,1 @@
+from app.routes import notices

--- a/backend/app/routes/notices.py
+++ b/backend/app/routes/notices.py
@@ -1,0 +1,65 @@
+from fastapi import APIRouter, HTTPException, status
+from bson import ObjectId
+from datetime import datetime, timezone
+
+from app.database import notices_collection
+from app.models import NoticeCreate, NoticeResponse
+
+router = APIRouter()
+
+
+def _serialize_notice(doc: dict) -> NoticeResponse:
+    return NoticeResponse(
+        id=str(doc["_id"]),
+        title=doc["title"],
+        content=doc["content"],
+        author=doc["author"],
+        created_at=doc["created_at"],
+    )
+
+
+# --- User routes ---
+
+@router.get("/notices", response_model=list[NoticeResponse], tags=["user"])
+async def get_notices():
+    """Return all notices for the public noticeboard."""
+    docs = await notices_collection.find().sort("created_at", -1).to_list(length=None)
+    return [_serialize_notice(d) for d in docs]
+
+
+# --- Admin routes ---
+
+@router.get("/admin/notices", response_model=list[NoticeResponse], tags=["admin"])
+async def admin_get_notices():
+    """Return all notices for the admin view."""
+    docs = await notices_collection.find().sort("created_at", -1).to_list(length=None)
+    return [_serialize_notice(d) for d in docs]
+
+
+@router.post(
+    "/admin/notices",
+    response_model=NoticeResponse,
+    status_code=status.HTTP_201_CREATED,
+    tags=["admin"],
+)
+async def admin_create_notice(notice: NoticeCreate):
+    """Create a new notice."""
+    doc = notice.model_dump()
+    doc["created_at"] = datetime.now(timezone.utc)
+    result = await notices_collection.insert_one(doc)
+    created = await notices_collection.find_one({"_id": result.inserted_id})
+    return _serialize_notice(created)
+
+
+@router.delete(
+    "/admin/notices/{notice_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    tags=["admin"],
+)
+async def admin_delete_notice(notice_id: str):
+    """Delete a notice by ID."""
+    if not ObjectId.is_valid(notice_id):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid notice ID")
+    result = await notices_collection.delete_one({"_id": ObjectId(notice_id)})
+    if result.deleted_count == 0:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Notice not found")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  frontend:
+    build: ./frontend
+    ports:
+      - "80:80"
+    depends_on:
+      - api
+    restart: unless-stopped
+
+  api:
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      MONGO_URL: mongodb://mongo:27017
+      DB_NAME: noticeboard
+    depends_on:
+      mongo:
+        condition: service_healthy
+    restart: unless-stopped
+
+  mongo:
+    image: mongo:7
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo_data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+volumes:
+  mongo_data:

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY backend/ ./backend/
+
+EXPOSE 8000
+
+CMD ["uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package.json .
+RUN npm install
+COPY . .
+RUN npm run build
+
+# Serve stage
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Noticeboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,18 @@
+server {
+    listen 80;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Proxy /api/* → FastAPI backend (strips /api prefix)
+    location /api/ {
+        proxy_pass http://api:8000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    # SPA fallback — all other routes serve index.html
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "noticeboard-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.24.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.1",
+    "vite": "^5.3.1"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,23 @@
+import { BrowserRouter, Routes, Route, NavLink } from "react-router-dom";
+import UserBoard from "./pages/UserBoard";
+import AdminBoard from "./pages/AdminBoard";
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <header className="site-header">
+        <h1>Noticeboard</h1>
+        <nav>
+          <NavLink to="/" end>Board</NavLink>
+          <NavLink to="/admin">Admin</NavLink>
+        </nav>
+      </header>
+      <main>
+        <Routes>
+          <Route path="/" element={<UserBoard />} />
+          <Route path="/admin" element={<AdminBoard />} />
+        </Routes>
+      </main>
+    </BrowserRouter>
+  );
+}

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,22 @@
+const BASE = "/api";
+
+export async function getNotices() {
+  const res = await fetch(`${BASE}/notices`);
+  if (!res.ok) throw new Error("Failed to fetch notices");
+  return res.json();
+}
+
+export async function createNotice(notice) {
+  const res = await fetch(`${BASE}/admin/notices`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(notice),
+  });
+  if (!res.ok) throw new Error("Failed to create notice");
+  return res.json();
+}
+
+export async function deleteNotice(id) {
+  const res = await fetch(`${BASE}/admin/notices/${id}`, { method: "DELETE" });
+  if (!res.ok) throw new Error("Failed to delete notice");
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,119 @@
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: system-ui, sans-serif;
+  background: #f4f5f7;
+  color: #1a1a2e;
+}
+
+/* ── Header ── */
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 2rem;
+  background: #1a1a2e;
+  color: #fff;
+}
+
+.site-header h1 { font-size: 1.4rem; letter-spacing: 0.05em; }
+
+.site-header nav { display: flex; gap: 1.5rem; }
+
+.site-header nav a {
+  color: #ccc;
+  text-decoration: none;
+  font-weight: 500;
+  transition: color 0.2s;
+}
+
+.site-header nav a:hover,
+.site-header nav a.active { color: #fff; }
+
+/* ── Layout ── */
+main { max-width: 800px; margin: 2rem auto; padding: 0 1rem; }
+
+/* ── Notice list ── */
+.board h2 { margin-bottom: 1.5rem; font-size: 1.3rem; }
+
+.notice-list { list-style: none; display: flex; flex-direction: column; gap: 1rem; }
+
+.notice-card {
+  background: #fff;
+  border-radius: 8px;
+  padding: 1.2rem 1.4rem;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.08);
+}
+
+.notice-card h3 { margin-bottom: 0.5rem; font-size: 1.1rem; }
+.notice-card p  { color: #444; line-height: 1.5; }
+
+.notice-card footer {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 0.8rem;
+  font-size: 0.82rem;
+  color: #888;
+}
+
+/* ── Form ── */
+.notice-form {
+  background: #fff;
+  border-radius: 8px;
+  padding: 1.4rem;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.08);
+  margin-bottom: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.notice-form h3 { font-size: 1rem; margin-bottom: 0.2rem; }
+
+.notice-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.notice-form input,
+.notice-form textarea {
+  border: 1px solid #d0d0d0;
+  border-radius: 6px;
+  padding: 0.5rem 0.7rem;
+  font-size: 1rem;
+  font-family: inherit;
+  width: 100%;
+}
+
+.notice-form button {
+  align-self: flex-start;
+  padding: 0.55rem 1.4rem;
+  background: #1a1a2e;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+
+.notice-form button:disabled { opacity: 0.6; cursor: not-allowed; }
+
+/* ── Delete button ── */
+.btn-delete {
+  margin-left: auto;
+  padding: 0.25rem 0.8rem;
+  background: #e74c3c;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+/* ── Status messages ── */
+.status { text-align: center; color: #666; padding: 2rem 0; }
+.status.error { color: #e74c3c; }

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root")).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/pages/AdminBoard.jsx
+++ b/frontend/src/pages/AdminBoard.jsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from "react";
+import { getNotices, createNotice, deleteNotice } from "../api";
+
+const EMPTY_FORM = { title: "", content: "", author: "Admin" };
+
+export default function AdminBoard() {
+  const [notices, setNotices] = useState([]);
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+
+  const fetchNotices = () =>
+    getNotices()
+      .then(setNotices)
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+
+  useEffect(() => { fetchNotices(); }, []);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      await createNotice(form);
+      setForm(EMPTY_FORM);
+      await fetchNotices();
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDelete = async (id) => {
+    setError(null);
+    try {
+      await deleteNotice(id);
+      setNotices((prev) => prev.filter((n) => n.id !== id));
+    } catch (e) {
+      setError(e.message);
+    }
+  };
+
+  return (
+    <section className="board">
+      <h2>Admin — Manage Notices</h2>
+
+      <form className="notice-form" onSubmit={handleSubmit}>
+        <h3>Post a New Notice</h3>
+        <label>
+          Title
+          <input
+            required
+            value={form.title}
+            onChange={(e) => setForm({ ...form, title: e.target.value })}
+          />
+        </label>
+        <label>
+          Content
+          <textarea
+            required
+            rows={4}
+            value={form.content}
+            onChange={(e) => setForm({ ...form, content: e.target.value })}
+          />
+        </label>
+        <label>
+          Author
+          <input
+            value={form.author}
+            onChange={(e) => setForm({ ...form, author: e.target.value })}
+          />
+        </label>
+        <button type="submit" disabled={submitting}>
+          {submitting ? "Posting…" : "Post Notice"}
+        </button>
+      </form>
+
+      {error && <p className="status error">{error}</p>}
+
+      {loading ? (
+        <p className="status">Loading…</p>
+      ) : notices.length === 0 ? (
+        <p className="status">No notices yet.</p>
+      ) : (
+        <ul className="notice-list">
+          {notices.map((n) => (
+            <li key={n.id} className="notice-card">
+              <h3>{n.title}</h3>
+              <p>{n.content}</p>
+              <footer>
+                <span>{n.author}</span>
+                <span>{new Date(n.created_at).toLocaleDateString()}</span>
+                <button
+                  className="btn-delete"
+                  onClick={() => handleDelete(n.id)}
+                >
+                  Delete
+                </button>
+              </footer>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/pages/UserBoard.jsx
+++ b/frontend/src/pages/UserBoard.jsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+import { getNotices } from "../api";
+
+export default function UserBoard() {
+  const [notices, setNotices] = useState([]);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    getNotices()
+      .then(setNotices)
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <p className="status">Loading notices…</p>;
+  if (error) return <p className="status error">{error}</p>;
+
+  return (
+    <section className="board">
+      <h2>Notices</h2>
+      {notices.length === 0 ? (
+        <p className="status">No notices yet.</p>
+      ) : (
+        <ul className="notice-list">
+          {notices.map((n) => (
+            <li key={n.id} className="notice-card">
+              <h3>{n.title}</h3>
+              <p>{n.content}</p>
+              <footer>
+                <span>{n.author}</span>
+                <span>{new Date(n.created_at).toLocaleDateString()}</span>
+              </footer>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    // Dev proxy so the frontend can reach the backend without CORS issues
+    proxy: {
+      "/api": {
+        target: "http://localhost:8000",
+        rewrite: (path) => path.replace(/^\/api/, ""),
+      },
+    },
+  },
+});

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi>=0.111.0
+uvicorn[standard]>=0.29.0
+motor>=3.4.0
+pydantic>=2.7.0
+python-dotenv>=1.0.0

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -1,0 +1,78 @@
+resource "aws_lb" "main" {
+  name               = "${var.app_name}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = aws_subnet.public[*].id
+
+  tags = { Name = "${var.app_name}-alb" }
+}
+
+# ── Target groups ─────────────────────────────────────────────────────────────
+resource "aws_lb_target_group" "frontend" {
+  name        = "${var.app_name}-frontend-tg"
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.main.id
+  target_type = "ip"
+
+  health_check {
+    path                = "/"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    interval            = 30
+  }
+
+  tags = { Name = "${var.app_name}-frontend-tg" }
+}
+
+resource "aws_lb_target_group" "backend" {
+  name        = "${var.app_name}-backend-tg"
+  port        = 8000
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.main.id
+  target_type = "ip"
+
+  health_check {
+    path                = "/health"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    interval            = 30
+  }
+
+  tags = { Name = "${var.app_name}-backend-tg" }
+}
+
+# ── Listener ─────────────────────────────────────────────────────────────────
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  # Default: send to frontend
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.frontend.arn
+  }
+}
+
+# /api/* → backend (strip /api prefix before forwarding)
+resource "aws_lb_listener_rule" "api" {
+  listener_arn = aws_lb_listener.http.arn
+  priority     = 10
+
+  condition {
+    path_pattern {
+      values = ["/api/*"]
+    }
+  }
+
+  action {
+    type = "forward"
+    forward {
+      target_group {
+        arn = aws_lb_target_group.backend.arn
+      }
+    }
+  }
+}

--- a/terraform/cleanup-iam.tf
+++ b/terraform/cleanup-iam.tf
@@ -172,6 +172,102 @@ resource "aws_iam_user_policy" "cleanup" {
         ]
         Resource = "*"
       },
+      # ECS / Fargate
+      {
+        Sid    = "ECSCleanup"
+        Effect = "Allow"
+        Action = [
+          "ecs:ListClusters",
+          "ecs:DescribeClusters",
+          "ecs:DeleteCluster",
+          "ecs:ListServices",
+          "ecs:DescribeServices",
+          "ecs:DeleteService",
+          "ecs:UpdateService",
+          "ecs:ListTaskDefinitions",
+          "ecs:DeregisterTaskDefinition",
+          "ecs:ListTagsForResource",
+        ]
+        Resource = "*"
+      },
+      # ECR
+      {
+        Sid    = "ECRCleanup"
+        Effect = "Allow"
+        Action = [
+          "ecr:DescribeRepositories",
+          "ecr:DeleteRepository",
+          "ecr:ListTagsForResource",
+          "ecr:BatchDeleteImage",
+          "ecr:ListImages",
+        ]
+        Resource = "*"
+      },
+      # DocumentDB
+      {
+        Sid    = "DocDBCleanup"
+        Effect = "Allow"
+        Action = [
+          "rds:DescribeDBClusters",
+          "rds:DeleteDBCluster",
+          "rds:DescribeDBInstances",
+          "rds:DeleteDBInstance",
+          "rds:ListTagsForResource",
+          "rds:DescribeDBSubnetGroups",
+          "rds:DeleteDBSubnetGroup",
+          "rds:DescribeDBClusterParameterGroups",
+          "rds:DeleteDBClusterParameterGroup",
+        ]
+        Resource = "*"
+      },
+      # Secrets Manager
+      {
+        Sid    = "SecretsManagerCleanup"
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:ListSecrets",
+          "secretsmanager:DescribeSecret",
+          "secretsmanager:DeleteSecret",
+          "secretsmanager:ListSecretVersionIds",
+          "secretsmanager:TagResource",
+        ]
+        Resource = "*"
+      },
+      # ALB / ELBv2
+      {
+        Sid    = "ALBCleanup"
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:DescribeLoadBalancers",
+          "elasticloadbalancing:DeleteLoadBalancer",
+          "elasticloadbalancing:DescribeTargetGroups",
+          "elasticloadbalancing:DeleteTargetGroup",
+          "elasticloadbalancing:DescribeListeners",
+          "elasticloadbalancing:DeleteListener",
+          "elasticloadbalancing:DescribeTags",
+        ]
+        Resource = "*"
+      },
+      # VPC networking (NAT GWs, EIPs already partly covered by EC2 above)
+      {
+        Sid    = "VPCCleanup"
+        Effect = "Allow"
+        Action = [
+          "ec2:DescribeVpcs",
+          "ec2:DeleteVpc",
+          "ec2:DescribeSubnets",
+          "ec2:DeleteSubnet",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DeleteSecurityGroup",
+          "ec2:DescribeInternetGateways",
+          "ec2:DetachInternetGateway",
+          "ec2:DeleteInternetGateway",
+          "ec2:DescribeRouteTables",
+          "ec2:DeleteRouteTable",
+          "ec2:DisassociateRouteTable",
+        ]
+        Resource = "*"
+      },
     ]
   })
 }

--- a/terraform/documentdb.tf
+++ b/terraform/documentdb.tf
@@ -1,0 +1,44 @@
+resource "aws_docdb_subnet_group" "main" {
+  name       = "${var.app_name}-docdb-subnet-group"
+  subnet_ids = aws_subnet.private[*].id
+  tags       = { Name = "${var.app_name}-docdb-subnet-group" }
+}
+
+resource "aws_docdb_cluster_parameter_group" "main" {
+  family      = "docdb5.0"
+  name        = "${var.app_name}-docdb-params"
+  description = "Noticeboard DocumentDB parameter group"
+
+  parameter {
+    name  = "tls"
+    value = "disabled" # Simplifies workshop connection strings; enable for production
+  }
+
+  tags = { Name = "${var.app_name}-docdb-params" }
+}
+
+resource "aws_docdb_cluster" "main" {
+  cluster_identifier              = "${var.app_name}-docdb"
+  engine                          = "docdb"
+  master_username                 = var.docdb_master_username
+  master_password                 = random_password.docdb.result
+  db_subnet_group_name            = aws_docdb_subnet_group.main.name
+  db_cluster_parameter_group_name = aws_docdb_cluster_parameter_group.main.name
+  vpc_security_group_ids          = [aws_security_group.docdb.id]
+  skip_final_snapshot             = true
+
+  tags = { Name = "${var.app_name}-docdb" }
+}
+
+resource "aws_docdb_cluster_instance" "main" {
+  identifier         = "${var.app_name}-docdb-instance"
+  cluster_identifier = aws_docdb_cluster.main.id
+  instance_class     = var.docdb_instance_class
+  tags               = { Name = "${var.app_name}-docdb-instance" }
+}
+
+resource "random_password" "docdb" {
+  length           = 20
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -1,0 +1,56 @@
+resource "aws_ecr_repository" "backend" {
+  name                 = "${var.app_name}-backend"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = { Name = "${var.app_name}-backend" }
+}
+
+resource "aws_ecr_repository" "frontend" {
+  name                 = "${var.app_name}-frontend"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = { Name = "${var.app_name}-frontend" }
+}
+
+# Keep only the last 5 images to control storage costs
+resource "aws_ecr_lifecycle_policy" "backend" {
+  repository = aws_ecr_repository.backend.name
+
+  policy = jsonencode({
+    rules = [{
+      rulePriority = 1
+      description  = "Keep last 5 images"
+      selection = {
+        tagStatus   = "any"
+        countType   = "imageCountMoreThan"
+        countNumber = 5
+      }
+      action = { type = "expire" }
+    }]
+  })
+}
+
+resource "aws_ecr_lifecycle_policy" "frontend" {
+  repository = aws_ecr_repository.frontend.name
+
+  policy = jsonencode({
+    rules = [{
+      rulePriority = 1
+      description  = "Keep last 5 images"
+      selection = {
+        tagStatus   = "any"
+        countType   = "imageCountMoreThan"
+        countNumber = 5
+      }
+      action = { type = "expire" }
+    }]
+  })
+}

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -1,0 +1,134 @@
+resource "aws_cloudwatch_log_group" "backend" {
+  name              = "/ecs/${var.app_name}/backend"
+  retention_in_days = 7
+  tags              = { Name = "${var.app_name}-backend-logs" }
+}
+
+resource "aws_cloudwatch_log_group" "frontend" {
+  name              = "/ecs/${var.app_name}/frontend"
+  retention_in_days = 7
+  tags              = { Name = "${var.app_name}-frontend-logs" }
+}
+
+resource "aws_ecs_cluster" "main" {
+  name = "${var.app_name}-cluster"
+  tags = { Name = "${var.app_name}-cluster" }
+}
+
+# ── Backend task ──────────────────────────────────────────────────────────────
+resource "aws_ecs_task_definition" "backend" {
+  family                   = "${var.app_name}-backend"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.backend_cpu
+  memory                   = var.backend_memory
+  execution_role_arn       = aws_iam_role.ecs_execution.arn
+  task_role_arn            = aws_iam_role.ecs_task.arn
+
+  container_definitions = jsonencode([{
+    name  = "backend"
+    image = var.backend_image != "" ? var.backend_image : "${aws_ecr_repository.backend.repository_url}:latest"
+
+    portMappings = [{ containerPort = 8000, protocol = "tcp" }]
+
+    # MONGO_URL is pulled from Secrets Manager at task start
+    secrets = [{
+      name      = "MONGO_URL"
+      valueFrom = aws_secretsmanager_secret.docdb.arn
+    }]
+
+    environment = [{
+      name  = "DB_NAME"
+      value = "noticeboard"
+    }]
+
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        awslogs-group         = aws_cloudwatch_log_group.backend.name
+        awslogs-region        = var.aws_region
+        awslogs-stream-prefix = "backend"
+      }
+    }
+  }])
+
+  tags = { Name = "${var.app_name}-backend-task" }
+}
+
+# ── Frontend task ─────────────────────────────────────────────────────────────
+resource "aws_ecs_task_definition" "frontend" {
+  family                   = "${var.app_name}-frontend"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.frontend_cpu
+  memory                   = var.frontend_memory
+  execution_role_arn       = aws_iam_role.ecs_execution.arn
+  task_role_arn            = aws_iam_role.ecs_task.arn
+
+  container_definitions = jsonencode([{
+    name  = "frontend"
+    image = var.frontend_image != "" ? var.frontend_image : "${aws_ecr_repository.frontend.repository_url}:latest"
+
+    portMappings = [{ containerPort = 80, protocol = "tcp" }]
+
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        awslogs-group         = aws_cloudwatch_log_group.frontend.name
+        awslogs-region        = var.aws_region
+        awslogs-stream-prefix = "frontend"
+      }
+    }
+  }])
+
+  tags = { Name = "${var.app_name}-frontend-task" }
+}
+
+# ── ECS Services ──────────────────────────────────────────────────────────────
+resource "aws_ecs_service" "backend" {
+  name            = "${var.app_name}-backend"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.backend.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = aws_subnet.private[*].id
+    security_groups  = [aws_security_group.backend.id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.backend.arn
+    container_name   = "backend"
+    container_port   = 8000
+  }
+
+  depends_on = [aws_lb_listener_rule.api]
+
+  tags = { Name = "${var.app_name}-backend-service" }
+}
+
+resource "aws_ecs_service" "frontend" {
+  name            = "${var.app_name}-frontend"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.frontend.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = aws_subnet.private[*].id
+    security_groups  = [aws_security_group.frontend.id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.frontend.arn
+    container_name   = "frontend"
+    container_port   = 80
+  }
+
+  depends_on = [aws_lb_listener.http]
+
+  tags = { Name = "${var.app_name}-frontend-service" }
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,43 @@
+data "aws_iam_policy_document" "ecs_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+# ── Task execution role (pull images, write logs) ─────────────────────────────
+resource "aws_iam_role" "ecs_execution" {
+  name               = "${var.app_name}-ecs-execution-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume.json
+  tags               = { Name = "${var.app_name}-ecs-execution-role" }
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_execution_managed" {
+  role       = aws_iam_role.ecs_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# Allow execution role to read the DocumentDB secret for injection into tasks
+resource "aws_iam_role_policy" "ecs_execution_secrets" {
+  name = "${var.app_name}-ecs-execution-secrets"
+  role = aws_iam_role.ecs_execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["secretsmanager:GetSecretValue"]
+      Resource = aws_secretsmanager_secret.docdb.arn
+    }]
+  })
+}
+
+# ── Task role (runtime permissions for the application itself) ────────────────
+resource "aws_iam_role" "ecs_task" {
+  name               = "${var.app_name}-ecs-task-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume.json
+  tags               = { Name = "${var.app_name}-ecs-task-role" }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,24 @@
+output "alb_dns_name" {
+  description = "Public URL of the noticeboard (open in browser)"
+  value       = "http://${aws_lb.main.dns_name}"
+}
+
+output "backend_ecr_url" {
+  description = "ECR URI for the backend image — use in docker push"
+  value       = aws_ecr_repository.backend.repository_url
+}
+
+output "frontend_ecr_url" {
+  description = "ECR URI for the frontend image — use in docker push"
+  value       = aws_ecr_repository.frontend.repository_url
+}
+
+output "docdb_endpoint" {
+  description = "DocumentDB cluster endpoint"
+  value       = aws_docdb_cluster.main.endpoint
+}
+
+output "ecr_login_command" {
+  description = "Run this to authenticate Docker with ECR"
+  value       = "aws ecr get-login-password --region ${var.aws_region} | docker login --username AWS --password-stdin ${aws_ecr_repository.backend.repository_url}"
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+
+  # Optional: uncomment to store state in S3
+  # backend "s3" {
+  #   bucket = "your-tf-state-bucket"
+  #   key    = "noticeboard/terraform.tfstate"
+  #   region = var.aws_region
+  # }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.common_tags
+  }
+}

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -1,0 +1,12 @@
+resource "aws_secretsmanager_secret" "docdb" {
+  name                    = "${var.app_name}/docdb-url"
+  recovery_window_in_days = 0 # Allow immediate deletion for workshop teardown
+  tags                    = { Name = "${var.app_name}-docdb-url" }
+}
+
+resource "aws_secretsmanager_secret_version" "docdb" {
+  secret_id = aws_secretsmanager_secret.docdb.id
+
+  # mongodb:// URI injected directly as MONGO_URL into ECS tasks
+  secret_string = "mongodb://${var.docdb_master_username}:${random_password.docdb.result}@${aws_docdb_cluster.main.endpoint}:27017/?directConnection=true"
+}

--- a/terraform/security-groups.tf
+++ b/terraform/security-groups.tf
@@ -1,0 +1,91 @@
+# ── ALB ──────────────────────────────────────────────────────────────────────
+resource "aws_security_group" "alb" {
+  name        = "${var.app_name}-alb-sg"
+  description = "Allow HTTP from the internet"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "${var.app_name}-alb-sg" }
+}
+
+# ── Frontend ECS tasks ────────────────────────────────────────────────────────
+resource "aws_security_group" "frontend" {
+  name        = "${var.app_name}-frontend-sg"
+  description = "Allow port 80 from ALB only"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 80
+    to_port         = 80
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "${var.app_name}-frontend-sg" }
+}
+
+# ── Backend ECS tasks ─────────────────────────────────────────────────────────
+resource "aws_security_group" "backend" {
+  name        = "${var.app_name}-backend-sg"
+  description = "Allow port 8000 from ALB only"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 8000
+    to_port         = 8000
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "${var.app_name}-backend-sg" }
+}
+
+# ── DocumentDB ────────────────────────────────────────────────────────────────
+resource "aws_security_group" "docdb" {
+  name        = "${var.app_name}-docdb-sg"
+  description = "Allow MongoDB port from backend tasks only"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 27017
+    to_port         = 27017
+    protocol        = "tcp"
+    security_groups = [aws_security_group.backend.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "${var.app_name}-docdb-sg" }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,63 @@
+# ── AWS ──────────────────────────────────────────────────────────────────────
+variable "aws_region" {
+  description = "AWS region to deploy into"
+  default     = "us-east-1"
+}
+
+# ── Networking ────────────────────────────────────────────────────────────────
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  default     = "10.0.0.0/16"
+}
+
+variable "availability_zones" {
+  description = "AZs to spread across (two required)"
+  type        = list(string)
+  default     = ["us-east-1a", "us-east-1b"]
+}
+
+# ── App ───────────────────────────────────────────────────────────────────────
+variable "app_name" {
+  description = "Short name used to prefix all noticeboard resources"
+  default     = "noticeboard"
+}
+
+variable "backend_image" {
+  description = "Full ECR URI for the backend image (set after first push)"
+  default     = ""
+}
+
+variable "frontend_image" {
+  description = "Full ECR URI for the frontend image (set after first push)"
+  default     = ""
+}
+
+# ── ECS ───────────────────────────────────────────────────────────────────────
+variable "backend_cpu" {
+  description = "Fargate vCPU units for the backend task"
+  default     = 256
+}
+
+variable "backend_memory" {
+  description = "Fargate memory (MiB) for the backend task"
+  default     = 512
+}
+
+variable "frontend_cpu" {
+  default = 256
+}
+
+variable "frontend_memory" {
+  default = 512
+}
+
+# ── DocumentDB ───────────────────────────────────────────────────────────────
+variable "docdb_instance_class" {
+  description = "DocumentDB instance class"
+  default     = "db.t3.medium"
+}
+
+variable "docdb_master_username" {
+  description = "DocumentDB master username"
+  default     = "noticeadmin"
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,0 +1,83 @@
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = { Name = "${var.app_name}-vpc" }
+}
+
+# ── Public subnets (ALB) ──────────────────────────────────────────────────────
+resource "aws_subnet" "public" {
+  count                   = 2
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(var.vpc_cidr, 8, count.index)
+  availability_zone       = var.availability_zones[count.index]
+  map_public_ip_on_launch = true
+
+  tags = { Name = "${var.app_name}-public-${count.index + 1}" }
+}
+
+# ── Private subnets (ECS tasks, DocumentDB) ───────────────────────────────────
+resource "aws_subnet" "private" {
+  count             = 2
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, count.index + 10)
+  availability_zone = var.availability_zones[count.index]
+
+  tags = { Name = "${var.app_name}-private-${count.index + 1}" }
+}
+
+# ── Internet Gateway ──────────────────────────────────────────────────────────
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+  tags   = { Name = "${var.app_name}-igw" }
+}
+
+# ── NAT Gateway (single, in first public subnet) ─────────────────────────────
+resource "aws_eip" "nat" {
+  domain = "vpc"
+  tags   = { Name = "${var.app_name}-nat-eip" }
+}
+
+resource "aws_nat_gateway" "main" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.public[0].id
+  tags          = { Name = "${var.app_name}-nat" }
+
+  depends_on = [aws_internet_gateway.main]
+}
+
+# ── Route tables ─────────────────────────────────────────────────────────────
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = { Name = "${var.app_name}-rt-public" }
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.main.id
+  }
+
+  tags = { Name = "${var.app_name}-rt-private" }
+}
+
+resource "aws_route_table_association" "public" {
+  count          = 2
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "private" {
+  count          = 2
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private.id
+}


### PR DESCRIPTION
Create the notice board files. The backend uses fastapi as the base. It has two pages one for the users that displays the current notices and one for the admins that displays the notices while also allowing them to add and delete notices. The notices are stored in mongoDB and they store the title, the content, the author, and the time of posting.